### PR TITLE
Add feature to only query server once if ghost is not available

### DIFF
--- a/mk64.js
+++ b/mk64.js
@@ -136,8 +136,6 @@ function find_char_id(character){
 
 //Function to set ghost character, then resume emulator
 function write_ghost_char(data){
-    console.log("The char ID is:")
-    console.log(data);
     mem.setblock(0x80162F23, data);
 }
 

--- a/mk64.js
+++ b/mk64.js
@@ -1,6 +1,6 @@
 /*MK64 is the script which interfaces with the Mario Kart 64 (EU) ROM using the latest
 PJ64 emulator. It also interfaces with the "MK64 Watcher.exe" time and ghost manager*/
-var WRITE_FLAG = false;
+var WRITE_FLAG = 0;
 var CHARACTER_ID = null;
 var TRACK_ID = null;
 var MIO0_DATA = null;
@@ -10,9 +10,6 @@ console.log("Running MK64 script...");
 //----TODOS:
 //Test when the onexec(0x80091F60 function triggers, if no ghosts are saved, it doesn't trigger! How do we account for this?
 //Do we have to close the socket each time? Should we? Look into adding it to the end of the query_socket function, not doing this!
-//Think of how to not trigger onexec() twice, since it'll query the server twice
-    //- Maybe the writeflag variable should be 0,1,2 (0=false, 1=true, 2=special)
-    //- if set to 2, that means we checked, it was false, but we do a check in onexec() and it will not  break again! And set to 0 again after??
 //Don't do server queries if it's not up, how do we do this?
 //Verify correct wording of character dk (DK, d.k.)?
 
@@ -21,10 +18,22 @@ console.log("Running MK64 script...");
 //Event to trigger when game checks if stage has saved ghost, trick game into thinking it does!
 events.onexec(0x80091F60, function(e) {
     debug.breakhere(true);
-    console.log("Character compare command triggered!");
-    var trackId = cpu.gpr.s2;
-    var json_payload = {"function": "check_for_ghost", "trackId": trackId};
-    query_server(json_payload, read_ext_file);
+    if (WRITE_FLAG === 0) {
+        console.log("Character compare command triggered!");
+        var trackId = cpu.gpr.s2;
+        var json_payload = {"function": "check_for_ghost", "trackId": trackId};
+        query_server(json_payload, read_ext_file);
+    } else if (WRITE_FLAG === 2) {
+        //If we're here, it means we already checked once and a ghost was not available
+        //Reset flag, this way it only gets checked once
+        WRITE_FLAG = 0;
+        debug.resume();
+    } else {
+        //If we're here, something has gone wrong...
+        console.log("WRITE_FLAG is not 0 or 2! Something went wrong.");
+        WRITE_FLAG = 0;
+        debug.resume();
+    }
 });
 
 //Event when ghost char ID is read for rendering. Chars IDs are 0-8
@@ -32,10 +41,10 @@ events.onread(0x80162F20, function(e) {
     debug.breakhere(true);
 
     //Checks to make sure we actually want to write a ghost
-    if (WRITE_FLAG) {
+    if (WRITE_FLAG === 1) {
         console.log("Character read triggered!");
         write_ghost_char(CHARACTER_ID);
-        WRITE_FLAG = false; //Done loading, reset flag
+        WRITE_FLAG = 0; //Done loading, reset flag
     }
     debug.resume();  
 });
@@ -45,7 +54,7 @@ events.onexec(0x8000520C, function(e) {
     debug.breakhere(true);
 
     //Checks to make sure we actually want to write a ghost
-    if (WRITE_FLAG) {
+    if (WRITE_FLAG === 1) {
         console.log("MIO0 read triggered!");
         inject_MIO0(MIO0_DATA);
     }
@@ -95,13 +104,13 @@ function read_ext_file(data){
         CHARACTER_ID = new Buffer([find_char_id(fileJson['header']['character'])]);
         TRACK_ID = fileJson['header']['track']; //Do we need this as track id? Probably not? OR maybe for saving?
         MIO0_DATA = Duktape.dec('base64', fileJson['ghost']); //Decode base64 formatted input MIO0 Data
-        WRITE_FLAG = true;
+        WRITE_FLAG = 1;
 
         //Call the function that tricks the game into thinking it has a ghost
         course_match();
     } else {
         console.log("Ghost unavailable for this track.");
-        //TODO -Consider setting flag to 3rd option here!!
+        WRITE_FLAG = 2;
     }
 
     //Resume game

--- a/mk64.js
+++ b/mk64.js
@@ -1,6 +1,6 @@
 /*MK64 is the script which interfaces with the Mario Kart 64 (EU) ROM using the latest
 PJ64 emulator. It also interfaces with the "MK64 Watcher.exe" time and ghost manager*/
-var WRITE_FLAG = false;
+var WRITE_FLAG = 0;
 var CHARACTER_ID = null;
 var TRACK_ID = null;
 var MIO0_DATA = null;
@@ -21,10 +21,22 @@ console.log("Running MK64 script...");
 //Event to trigger when game checks if stage has saved ghost, trick game into thinking it does!
 events.onexec(0x80091F60, function(e) {
     debug.breakhere(true);
-    console.log("Character compare command triggered!");
-    var trackId = cpu.gpr.s2;
-    var json_payload = {"function": "check_for_ghost", "trackId": trackId};
-    query_server(json_payload, read_ext_file);
+    if (WRITE_FLAG === 0) {
+        console.log("Character compare command triggered!");
+        var trackId = cpu.gpr.s2;
+        var json_payload = {"function": "check_for_ghost", "trackId": trackId};
+        query_server(json_payload, read_ext_file);
+    } else if (WRITE_FLAG === 2) {
+        //If we're here, it means we already checked once and a ghost was not available
+        //Reset flag, this way it only gets checked once
+        WRITE_FLAG = 0;
+        debug.resume();
+    } else {
+        //If we're here, something has gone wrong...
+        console.log("WRITE_FLAG is not 0 or 2! Something went wrong.");
+        WRITE_FLAG = 0;
+        debug.resume();
+    }
 });
 
 //Event when ghost char ID is read for rendering. Chars IDs are 0-8
@@ -32,10 +44,10 @@ events.onread(0x80162F20, function(e) {
     debug.breakhere(true);
 
     //Checks to make sure we actually want to write a ghost
-    if (WRITE_FLAG) {
+    if (WRITE_FLAG === 1) {
         console.log("Character read triggered!");
         write_ghost_char(CHARACTER_ID);
-        WRITE_FLAG = false; //Done loading, reset flag
+        WRITE_FLAG = 0; //Done loading, reset flag
     }
     debug.resume();  
 });
@@ -45,7 +57,7 @@ events.onexec(0x8000520C, function(e) {
     debug.breakhere(true);
 
     //Checks to make sure we actually want to write a ghost
-    if (WRITE_FLAG) {
+    if (WRITE_FLAG === 1) {
         console.log("MIO0 read triggered!");
         inject_MIO0(MIO0_DATA);
     }
@@ -95,13 +107,13 @@ function read_ext_file(data){
         CHARACTER_ID = new Buffer([find_char_id(fileJson['header']['character'])]);
         TRACK_ID = fileJson['header']['track']; //Do we need this as track id? Probably not? OR maybe for saving?
         MIO0_DATA = Duktape.dec('base64', fileJson['ghost']); //Decode base64 formatted input MIO0 Data
-        WRITE_FLAG = true;
+        WRITE_FLAG = 1;
 
         //Call the function that tricks the game into thinking it has a ghost
         course_match();
     } else {
         console.log("Ghost unavailable for this track.");
-        //TODO -Consider setting flag to 3rd option here!!
+        WRITE_FLAG = 2;
     }
 
     //Resume game


### PR DESCRIPTION
Previously, if a ghost was not available, the game would query both slots of the memory card
if this happened, the function @0x80091F60 would execute twice, thus, our code would query the
server twice. This was not efficient since the response would always be the same.

By changing the WRITE_FLAG to contain 3 different states, we can account for this, and skip the second
query